### PR TITLE
Use `Folds` for `ThreadedProjMPOSum` multithreaded operations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.0.1"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+Folds = "41a02a25-b8f0-4f67-bc48-60067656b558"
 ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 

--- a/src/ITensorParallel.jl
+++ b/src/ITensorParallel.jl
@@ -1,6 +1,7 @@
 module ITensorParallel
 
 using Distributed
+using Folds
 using MPI
 using ITensors
 using ITensors.NDTensors


### PR DESCRIPTION
This should make them more robust and less error-prone.