### PR TITLE
Serialized collectives

### DIFF
--- a/src/ITensorParallel.jl
+++ b/src/ITensorParallel.jl
@@ -5,11 +5,12 @@ using MPI
 using ITensors
 using ITensors.NDTensors
 
-import ITensors: product, position!, noiseterm, lproj, rproj,nsite,replaceind!,linkind
+import ITensors: product, position!, noiseterm, lproj, rproj, nsite, replaceind!, linkind
 
 include("partition.jl")
 include("threaded_projmposum.jl")
 include("distributed_projmposum.jl")
+include("mpi_aux.jl")
 include("mpi_projmposum.jl")
 
 export ThreadedProjMPOSum, partition, DistributedSum, MPISum

--- a/src/ITensorParallel.jl
+++ b/src/ITensorParallel.jl
@@ -5,7 +5,7 @@ using MPI
 using ITensors
 using ITensors.NDTensors
 
-import ITensors: product, position!, noiseterm, lproj, rproj
+import ITensors: product, position!, noiseterm, lproj, rproj,nsite,replaceind!,linkind
 
 include("partition.jl")
 include("threaded_projmposum.jl")

--- a/src/mpi_aux.jl
+++ b/src/mpi_aux.jl
@@ -1,0 +1,49 @@
+
+"""
+bcast(obj, comm::Comm; root::Integer=Cint(0)) =
+    bcast(obj, root, comm)
+function bcast(obj, root::Integer, comm::Comm)
+    isroot = Comm_rank(comm) == root
+    count = Ref{Cint}()
+    if isroot
+        buf = MPI.serialize(obj)
+        count[] = length(buf)
+    end
+    Bcast!(count, root, comm)
+    if !isroot
+        buf = Array{UInt8}(undef, count[])
+    end
+    Bcast!(buf, root, comm)
+    if !isroot
+        obj = MPI.deserialize(buf)
+    end
+    return obj
+end
+"""
+
+_gather(obj, comm::MPI.Comm, root::Integer=Cint(0)) = _gather(obj, root, comm)
+function _gather(obj, root::Integer, comm::MPI.Comm)
+  isroot = MPI.Comm_rank(comm) == root
+  count = Ref{Cint}()
+  buf = MPI.serialize(obj)
+  count[] = length(buf)
+  counts = MPI.Gather(count[], root, comm)
+  if isroot
+    rbuf = Array{UInt8}(undef, reduce(+, counts))
+    rbuf = MPI.VBuffer(rbuf, counts)
+  else
+    rbuf = nothing
+  end
+  MPI.Gatherv!(buf, rbuf, root, comm)
+  if isroot
+    objs = []
+    for v in 1:length(rbuf.counts)
+      endind = v == length(rbuf.counts) ? length(rbuf.data) : rbuf.displs[v + 1] + 1
+      startind = rbuf.displs[v] + 1
+      push!(objs, MPI.deserialize(rbuf.data[startind:endind]))
+    end
+  else
+    objs = nothing
+  end
+  return objs
+end

--- a/src/mpi_projmposum.jl
+++ b/src/mpi_projmposum.jl
@@ -14,7 +14,7 @@ end
 
 MPISum(data::T, comm=MPI.COMM_WORLD) where {T} = MPISum{T}(data, comm)
 
-nsite(P::MPISum) = nsite(P.data)
+nsite(P::MPISum) = ITensors.nsite(P.data)
 
 Base.length(P::MPISum) = length(P.data)
 
@@ -22,7 +22,7 @@ function _Allreduce(sendbuf::ITensor, op, comm)
   return _Allreduce(NDTensors.storagetype(tensor(sendbuf)), sendbuf, op, comm)
 end
 
-function _Allreduce(::Type{<:BlockSparse}, sendbuf::ITensor, op, comm)
+function _Allreduce(::Type{<:BlockSparse}, sendbuf::ITensor, op, comm)  @deprecate
   # Similar to:
   #
   # recvbuf = ITensor(eltype(sendbuf), flux(sendbuf), inds(sendbuf))
@@ -30,6 +30,7 @@ function _Allreduce(::Type{<:BlockSparse}, sendbuf::ITensor, op, comm)
   # But more efficient.
   nprocs = MPI.Comm_size(comm)
   N = order(sendbuf)
+  @show MPI.Comm_rank(comm), nnzblocks(sendbuf)
   max_nblocks = maximum(MPI.Allgather(nnzblocks(sendbuf), comm))
   blocks_sendbuf = fill(0, max_nblocks, N)
   nzblocks_matrix = Matrix{Int}(reduce(hcat, collect.(nzblocks(sendbuf)))')
@@ -54,8 +55,24 @@ function _Allreduce(::Type{<:Dense}, sendbuf::ITensor, op, comm)
   return recvbuf
 end
 
+function _allreduce(sendbuf,op,comm::MPI.Comm)
+  ##maybe better to implement as allgather with local reduce, but higher communication cost associated
+  bufs=MPI.gather(sendbuf,0,comm)
+  rank=MPI.Comm_rank(comm)
+  if rank==0
+    if op==+
+      res=sum(bufs)
+    else
+      res=reduce(op,bufs)
+    end
+  else
+    res=nothing
+  end
+  return MPI.bcast(res,0,comm)
+end
+
 function product(P::MPISum, v::ITensor)
-  return _Allreduce(P.data(v), +, P.comm)
+  return _allreduce(P.data(v),+,P.comm)
 end
 
 function Base.eltype(P::MPISum)
@@ -66,11 +83,91 @@ end
 
 Base.size(P::MPISum) = size(P.data)
 
-function position!(P::MPISum, psi::MPS, pos::Int)
-  position!(P.data, psi, pos)
+
+function position!(P::MPISum{T}, psi::MPS, pos::Int)  where T<:ITensors.AbstractProjMPO
+  makeL!(P, psi, pos - 1)
+  makeR!(P, psi, pos + nsite(P))
   return P
 end
 
+function makeL!(P::MPISum, psi::MPS, k::Int)
+  _makeL!(P, psi, k)
+  return P
+end
+
+function makeR!(P::MPISum, psi::MPS, k::Int)
+  _makeR!(P, psi, k)
+  return P
+end
+
+
+
+function _makeL!(_P::MPISum, psi::MPS, k::Int)::Union{ITensor,Nothing}
+  # Save the last `L` that is made to help with caching
+  # for DiskProjMPO
+  P=_P.data
+  ll = P.lpos
+  if ll ≥ k
+    # Special case when nothing has to be done.
+    # Still need to change the position if lproj is
+    # being moved backward.
+    P.lpos = k
+    return nothing
+  end
+  # Make sure ll is at least 0 for the generic logic below
+  ll = max(ll, 0)
+  L = lproj(P)
+  while ll < k
+    # sync the linkindex across processes
+    mylink=linkind(psi,ll+1)
+    otherlink=MPI.bcast(mylink,0,_P.comm)
+    replaceind!(psi[ll+1],mylink,otherlink)
+    replaceind!(psi[ll+2],mylink,otherlink)
+    
+    L = L * psi[ll + 1] * P.H[ll + 1] * dag(prime(psi[ll + 1]))
+    P.LR[ll + 1] = L
+    ll += 1
+  end
+  # Needed when moving lproj backward.
+  P.lpos = k
+  return L
+end
+
+function _makeR!(_P::MPISum{ProjMPO}, psi::MPS, k::Int)::Union{ITensor,Nothing}
+  # Save the last `R` that is made to help with caching
+  # for DiskProjMPO
+  P=_P.data
+  rl = P.rpos
+  if rl ≤ k
+    # Special case when nothing has to be done.
+    # Still need to change the position if rproj is
+    # being moved backward.
+    P.rpos = k
+    return nothing
+  end
+  N = length(P.H)
+  # Make sure rl is no bigger than `N + 1` for the generic logic below
+  rl = min(rl, N + 1)
+  R = rproj(P)
+  while rl > k
+    #sync linkindex across processes
+    mylink=linkind(psi,rl-2)
+    otherlink=MPI.bcast(mylink,0,_P.comm)
+    replaceind!(psi[rl-2],mylink,otherlink)
+    replaceind!(psi[rl-1],mylink,otherlink)
+    
+    R = R * psi[rl - 1] * P.H[rl - 1] * dag(prime(psi[rl - 1]))
+    P.LR[rl - 1] = R
+    rl -= 1
+  end
+  P.rpos = k
+  return R
+end
+
+
+
 function noiseterm(P::MPISum, phi::ITensor, dir::String)
-  return _Allreduce(noiseterm(P.data, phi, dir), +, P.comm)
+  ##ToDo: I think the logic here is wrong.
+  ##The noiseterm should be calculated on the reduced P*v and then broadcasted?
+  return _allreduce(noiseterm(P.data, phi, dir), +, P.comm)
 end

--- a/src/mpi_projmposum.jl
+++ b/src/mpi_projmposum.jl
@@ -14,50 +14,13 @@ end
 
 MPISum(data::T, comm=MPI.COMM_WORLD) where {T} = MPISum{T}(data, comm)
 
-nsite(P::MPISum) = ITensors.nsite(P.data)
+nsite(P::MPISum) = nsite(P.data)
 
 Base.length(P::MPISum) = length(P.data)
 
-function _Allreduce(sendbuf::ITensor, op, comm)
-  return _Allreduce(NDTensors.storagetype(tensor(sendbuf)), sendbuf, op, comm)
-end
-
-function _Allreduce(::Type{<:BlockSparse}, sendbuf::ITensor, op, comm)  @deprecate
-  # Similar to:
-  #
-  # recvbuf = ITensor(eltype(sendbuf), flux(sendbuf), inds(sendbuf))
-  #
-  # But more efficient.
-  nprocs = MPI.Comm_size(comm)
-  N = order(sendbuf)
-  @show MPI.Comm_rank(comm), nnzblocks(sendbuf)
-  max_nblocks = maximum(MPI.Allgather(nnzblocks(sendbuf), comm))
-  blocks_sendbuf = fill(0, max_nblocks, N)
-  nzblocks_matrix = Matrix{Int}(reduce(hcat, collect.(nzblocks(sendbuf)))')
-  blocks_sendbuf[1:size(nzblocks_matrix, 1), :] = nzblocks_matrix
-  allblocks = MPI.Allgather(blocks_sendbuf, comm)
-  allblocks_tensor = reshape(allblocks, max_nblocks, N, nprocs)
-  allblocks_vector = [allblocks_tensor[:, :, i] for i in 1:nprocs]
-  allblocks_vector_tuple = [
-    [Tuple(allblocks_vector[n][i, :]) for i in 1:max_nblocks] for n in 1:nprocs
-  ]
-  blocks = Block.(filter(≠(ntuple(Returns(0), N)), union(allblocks_vector_tuple...)))
-  recvbuf = itensor(BlockSparseTensor(eltype(sendbuf), blocks, inds(sendbuf)))
-  sendbuf_filled = copy(recvbuf)
-  sendbuf_filled .= sendbuf
-  MPI.Allreduce!(sendbuf_filled, recvbuf, +, comm)
-  return recvbuf
-end
-
-function _Allreduce(::Type{<:Dense}, sendbuf::ITensor, op, comm)
-  recvbuf = similar(sendbuf)
-  MPI.Allreduce!(sendbuf, recvbuf, op, comm)
-  return recvbuf
-end
-
 function _allreduce(sendbuf,op,comm::MPI.Comm)
   ##maybe better to implement as allgather with local reduce, but higher communication cost associated
-  bufs=MPI.gather(sendbuf,0,comm)
+  bufs=_gather(sendbuf,0,comm)
   rank=MPI.Comm_rank(comm)
   if rank==0
     if op==+


### PR DESCRIPTION
This implements a serialized MPI collective routine `_gather` to be used in MPISum reduction across nodes via `_allreduce`. The prior implementation via `MPI.Allreduce` of the data of an ITensor required same index and block-ordering across nodes, making it failure-prone and is thus removed. Synchronization of linkindices across processes during a DMRG run is taken care of by reimplementation of `position!` for `MPISum`.
Closes #11 .