### PR TITLE
Add support for forcing the GC when using Distributed

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Folds = "41a02a25-b8f0-4f67-bc48-60067656b558"
 ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
@@ -12,6 +13,7 @@ MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 
 [compat]
 Accessors = "0.1.26"
+Compat = "4.8"
 Folds = "0.2.8"
 ITensors = "0.3.27"
 MPI = "0.20"

--- a/src/ITensorParallel.jl
+++ b/src/ITensorParallel.jl
@@ -27,6 +27,7 @@ import ITensors:
 include(joinpath("partition", "partition.jl"))
 include(joinpath("partition", "partition_sum_split.jl"))
 include(joinpath("partition", "partition_chain_split.jl"))
+include("force_gc.jl")
 include("foldssum.jl")
 include("distributedsum.jl")
 include("mpi_extensions.jl")

--- a/src/ITensorParallel.jl
+++ b/src/ITensorParallel.jl
@@ -1,6 +1,7 @@
 module ITensorParallel
 
 using Accessors
+using Compat
 using Distributed
 using Folds
 using MPI

--- a/src/distributedsum.jl
+++ b/src/distributedsum.jl
@@ -37,7 +37,7 @@ function position!(callback, term::Future, v::MPS, pos::Int)
 end
 
 function noiseterm(term::Future, v::ITensor, dir::String)
-  return noiseterm(() -> force_gc(), v, dir)
+  return noiseterm(() -> force_gc(), term, v, dir)
 end
 
 function noiseterm(callback, term::Future, v::ITensor, dir::String)

--- a/src/distributedsum.jl
+++ b/src/distributedsum.jl
@@ -1,32 +1,61 @@
+distribute(term) = @spawnat(:any, term)
+distribute(term::Future) = term
+distribute(term::MPO) = distribute(ProjMPO(term))
+
 # Functionality for distributed terms of a sum
 # onto seperate processes
-function distribute(terms::Vector)
-  return map(term -> @spawnat(:any, term), terms)
-end
-
-distribute(terms::Vector{Future}) = terms
-
-function distribute(terms::Vector{MPO})
-  return distribute(ProjMPO.(terms))
-end
+distribute(terms::Vector) = distribute.(terms)
 
 function DistributedSum(terms::Vector; executor_kwargs...)
   return FoldsSum(distribute(terms), SequentialEx(; executor_kwargs...))
 end
 
-function position!(term::Future, v::MPS, pos::Int)
-  return @spawnat term.where position!(fetch(term), v, pos)
-end
-
-function product(term::Future, v::ITensor)
-  return @fetchfrom term.where fetch(term)(v)
-end
 (term::Future)(v::ITensor) = product(term, v)
 
+function product(term::Future, v::ITensor)
+  return product(() -> force_gc(), term, v)
+end
+
+function product(callback, term::Future, v::ITensor)
+  return @fetchfrom term.where begin
+    res = fetch(term)(v)
+    callback()
+    return res
+  end
+end
+
+function position!(term::Future, v::MPS, pos::Int)
+  return position!(() -> force_gc(), term, v, pos)
+end
+
+function position!(callback, term::Future, v::MPS, pos::Int)
+  return @spawnat term.where begin
+    res = position!(fetch(term), v, pos)
+    callback()
+    return res
+  end
+end
+
 function noiseterm(term::Future, v::ITensor, dir::String)
-  return @fetchfrom term.where noiseterm(fetch(term), v, dir)
+  return noiseterm(() -> force_gc(), v, dir)
+end
+
+function noiseterm(callback, term::Future, v::ITensor, dir::String)
+  return @fetchfrom term.where begin
+    res = noiseterm(fetch(term), v, dir)
+    callback()
+    return res
+  end
 end
 
 function disk(term::Future; disk_kwargs...)
-  return @spawnat term.where disk(fetch(term); disk_kwargs...)
+  return disk(() -> force_gc(), term; disk_kwargs...)
+end
+
+function disk(callback, term::Future; disk_kwargs...)
+  return @spawnat term.where begin
+    res = disk(fetch(term); disk_kwargs...)
+    callback()
+    return res
+  end
 end

--- a/src/foldssum.jl
+++ b/src/foldssum.jl
@@ -70,7 +70,7 @@ function product(sum::FoldsSum{<:Any,<:DistributedEx}, v::ITensor)
 end
 
 function product(callback, sum::FoldsSum, v::ITensor)
-  return Folds.sum(terms(sum), executor(sum)) begin term
+  return Folds.sum(terms(sum), executor(sum)) do term
     res = term(v)
     callback()
     return res
@@ -86,7 +86,7 @@ function position!(sum::FoldsSum{<:Any,<:DistributedEx}, v::MPS, pos::Int)
 end
 
 function position!(callback, sum::FoldsSum, v::MPS, pos::Int)
-  new_terms = Folds.map(term -> position!(term, v, pos), terms(sum), executor(sum)) begin term
+  new_terms = Folds.map(terms(sum), executor(sum)) do term
     res = position!(term, v, pos)
     callback()
     return res
@@ -99,7 +99,7 @@ function noiseterm(sum::FoldsSum, v::ITensor, dir::String)
 end
 
 function noiseterm(callback, sum::FoldsSum, v::ITensor, dir::String)
-  return Folds.sum(terms(sum), executor(sum)) begin term
+  return Folds.sum(terms(sum), executor(sum)) do term
     res = noiseterm(term, v, dir)
     callback()
     return res

--- a/src/foldssum.jl
+++ b/src/foldssum.jl
@@ -95,7 +95,7 @@ function position!(callback, sum::FoldsSum, v::MPS, pos::Int)
 end
 
 function noiseterm(sum::FoldsSum, v::ITensor, dir::String)
-  return noiseterm(() -> force_gc(), v, dir)
+  return noiseterm(() -> force_gc(), sum, v, dir)
 end
 
 function noiseterm(callback, sum::FoldsSum, v::ITensor, dir::String)

--- a/src/force_gc.jl
+++ b/src/force_gc.jl
@@ -10,7 +10,7 @@ end
 # https://discourse.julialang.org/t/from-multithreading-to-distributed/101984/6
 function force_gc(gb_threshold::Real=get_gc_gb_threshold())
   if Sys.free_memory() < gb_threshold * 2^30
-     GC.gc()
+    GC.gc()
   end
   return nothing
 end

--- a/src/force_gc.jl
+++ b/src/force_gc.jl
@@ -1,0 +1,16 @@
+# Default to 6 GB threshold to trigger GC
+default_gc_gb_threshold() = 6.0
+const gc_gb_threshold = Ref(default_gc_gb_threshold())
+get_gc_gb_threshold() = gc_gb_threshold[]
+function set_gc_gb_threshold!(gb_threshold)
+  gc_gb_threshold[] = gb_threshold
+  return nothing
+end
+
+# https://discourse.julialang.org/t/from-multithreading-to-distributed/101984/6
+function force_gc(gb_threshold::Real=get_gc_gb_threshold())
+  if Sys.free_memory() < gb_threshold * 2^30
+     GC.gc()
+  end
+  return nothing
+end

--- a/src/mpisumterm.jl
+++ b/src/mpisumterm.jl
@@ -9,7 +9,7 @@ set_term(sumterm::MPISumTerm, term) = (@set sumterm.term = term)
 set_comm(sumterm::MPISumTerm, comm) = (@set sumterm.comm = comm)
 
 MPISumTerm(mpo::MPO, comm::MPI.Comm) = MPISumTerm(ProjMPO(mpo), comm)
-MPISumTerm(mpos::Vector{MPO},comm::MPI.Comm) = MPISumTerm(ProjMPOSum(mpos),comm)
+MPISumTerm(mpos::Vector{MPO}, comm::MPI.Comm) = MPISumTerm(ProjMPOSum(mpos), comm)
 
 nsite(sumterm::MPISumTerm) = nsite(term(sumterm))
 


### PR DESCRIPTION
This adds support for forcing Julia's garbage collector to run during certain operations when using the Distributed backend.

@nbaldelli was reporting that Julia was crashing when using the Distributed backend of ITensorParallel.jl with larger MPS bond dimensions. It may be related to issues with Julia not running the garbage collector properly when using Distributed parallelization, for example see https://discourse.julialang.org/t/from-multithreading-to-distributed/101984/6.

Currently by default it triggers the garbage collector to run within remote calls to applying the effective Hamiltonian, changing the position, etc. when there is less than 6GB of memory left on the process. This default can be changed with:
```julia
ITensorParallel.set_gc_gb_threshold!(3)
```
where the value is in GB. Setting it very large (i.e. `ITensorParallel.set_gc_gb_threshold!(Inf)`) means it always gets triggered in the operations where it is hard-coded in this PR, while setting it very small (i.e. `ITensorParallel.set_gc_gb_threshold!(0)`) means Julia will handle all garbage collection based on its default behavior.

@b-kloss @awietek